### PR TITLE
fix: Remove unnecessary backslashes from completion results

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -221,7 +221,15 @@ export class SelectorCompletionItemProvider implements CompletionItemProvider, D
     const classes = new Map<string, CompletionItem>();
 
     keys.forEach((key) =>
-      this.cache.get(key)?.forEach((e) => (e.kind === CompletionItemKind.Value ? ids : classes).set(e.label, e))
+      ////this.cache.get(key)?.forEach((e) => (e.kind === CompletionItemKind.Value ? ids : classes).set(e.label, e))
+      this.cache.get(key)?.forEach((e) => {
+        const res = e.kind === CompletionItemKind.Value ? ids : classes;
+        // ---- custom fix ----
+        e.label = e.label.replace('\\', '');
+        e.insertText = e.label.replace('\\', '');
+        // ---- /custom fix ----
+        res.set(e.label, e);
+      })
     );
 
     return { ids, classes };


### PR DESCRIPTION
## Description

In some cases, `\` is included in the completion data.

<img width="665" alt="coc-html-css-support-tailwind-remote" src="https://user-images.githubusercontent.com/188642/121343832-0bfa6480-c95e-11eb-9eb5-20222499c657.png">

## Fix

<img width="566" alt="fix-coc-html-css-support-tailwind-remote" src="https://user-images.githubusercontent.com/188642/121344488-c7bb9400-c95e-11eb-93c7-6cf1284995b4.png">
