### PR TITLE
feat(command): add "html-css-support.customDataSetup" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ HTML id and class attribute "completion" for [coc.nvim](https://github.com/neocl
 - Supports template inheritance.
 - Supports additional style sheets.
 - Supports other HTML like languages.
+- Command to make `html.customData` built-in in `coc-html-css-support` available at the workspace level.
+  - Require [coc-html](https://github.com/neoclide/coc-html)
 
 ## Configuration options
 
@@ -27,6 +29,9 @@ HTML id and class attribute "completion" for [coc.nvim](https://github.com/neocl
 ## Commands
 
 - `html-css-support.dispose`: Clear cache and reload the stylesheet
+- `html-css-support.customDataSetup`: Setup `html.customData` in workspace config. Supported customData are as follows
+  - `Alpine.js`
+  - `petite-vue`
 
 ## Example settings
 
@@ -60,6 +65,13 @@ HTML id and class attribute "completion" for [coc.nvim](https://github.com/neocl
     ]
 }
 ```
+
+## What is customData?
+
+You can read more about customData in the following repositories.
+
+- <https://github.com/microsoft/vscode-custom-data>
+- <https://github.com/Microsoft/vscode-html-languageservice/blob/main/docs/customData.md>
 
 ## Thanks
 

--- a/customData/alpinejs/html.json
+++ b/customData/alpinejs/html.json
@@ -1,0 +1,323 @@
+{
+  "version": "1.1",
+  "tags": [],
+  "globalAttributes": [
+    {
+      "name": "x-data",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-init",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-show",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-bind:",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-model",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-text",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-html",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-ref",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-if",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-for",
+      "description": "Alpine.js"
+    },
+    {
+      "name": ":key",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-transition:enter",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-transition:enter-start",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-transition:enter-end",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-transition:leave",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-transition:leave-start",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-transition:leave-end",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-cloak",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:abort",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:blur",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:canplay",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:canplaythrough",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:change",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:click",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:contextmenu",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:dblclick",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:drag",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:dragend",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:dragenter",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:dragleave",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:dragover",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:dragstart",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:drop",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:durationchange",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:emptied",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:ended",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:error",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:focus",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:input",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:invalid",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:keydown",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:keypress",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:keyup",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:load",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:loadeddata",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:loadedmetadata",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:loadstart",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:mousedown",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:mousemove",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:mouseout",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:mouseover",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:mouseup",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:pause",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:play",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:playing",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:progress",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:ratechange",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:reset",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:resize",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:readystatechange",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:scroll",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:seeked",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:seeking",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:select",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:show",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:stalled",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:submit",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:suspend",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:timeupdate",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:volumechange",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-on:waiting",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-bind:class",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-bind:disabled",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-bind:readonly",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-bind:required",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-bind:checked",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-bind:hidden",
+      "description": "Alpine.js"
+    },
+    {
+      "name": "x-bind:selected",
+      "description": "Alpine.js"
+    }
+  ],
+  "valueSets": []
+}

--- a/customData/petite-vue/html.json
+++ b/customData/petite-vue/html.json
@@ -1,0 +1,75 @@
+{
+  "version": "1.1",
+  "tags": [],
+  "globalAttributes": [
+    {
+      "name": "v-scope",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-effect",
+      "description": "petite-vue"
+    },
+    {
+      "name": "@mounted",
+      "description": "petite-vue"
+    },
+    {
+      "name": "@unmounted",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-bind:",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-on:",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-model",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-if",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-else",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-else-if",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-for",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-show",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-html",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-text",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-pre",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-once",
+      "description": "petite-vue"
+    },
+    {
+      "name": "v-cloak",
+      "description": "petite-vue"
+    }
+  ],
+  "valueSets": []
+}

--- a/package.json
+++ b/package.json
@@ -90,6 +90,10 @@
       {
         "command": "html-css-support.dispose",
         "title": "Clear cache and reload the stylesheet"
+      },
+      {
+        "command": "html-css-support.customDataSetup",
+        "title": "Setup `html.customData` to be used in the workspace"
       }
     ]
   }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,37 @@
+import { extensions, ExtensionContext, window, workspace } from 'coc.nvim';
+import path from 'path';
+
+export function customDataSetupCommand(context: ExtensionContext) {
+  return async () => {
+    if (!extensions.all.find((e) => e.id === 'coc-html')) {
+      window.showWarningMessage(`coc-html is not installed`);
+      return;
+    }
+
+    const htmlConfig = workspace.getConfiguration('html');
+    const picked = await window.showMenuPicker(['Alpine.js', 'petite-vue'], 'Which customData do you want to use?');
+
+    switch (picked) {
+      case -1:
+        // Cancel!
+        window.showMessage(`It's been cancelled`);
+        break;
+      case 0:
+        // Alpine.js
+        htmlConfig.update('customData', [path.join(context.extensionPath, 'customData', 'alpinejs', 'html.json')]);
+        break;
+      case 1:
+        // petite-vue
+        htmlConfig.update('customData', [path.join(context.extensionPath, 'customData', 'petite-vue', 'html.json')]);
+        break;
+      default:
+        // Cancel!
+        window.showMessage(`It's been cancelled`);
+        break;
+    }
+
+    if (picked !== -1) {
+      workspace.nvim.command(`CocRestart`, true);
+    }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { SelectorCompletionItemProvider } from './completion';
 import { ExtensionContext, commands, languages, workspace } from 'coc.nvim';
+import { customDataSetupCommand } from './commands';
 
 export async function activate(context: ExtensionContext): Promise<void> {
   const config = workspace.getConfiguration('html-css-support');
@@ -15,6 +16,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
     commands.registerCommand('html-css-support.dispose', () => provider.dispose()),
     languages.registerCompletionItemProvider('html-css-support', 'HCS', enabledLanguages, provider),
     provider
+  );
+
+  /** MEMO: Custom commands for coc-html-css-support */
+  context.subscriptions.push(
+    commands.registerCommand('html-css-support.customDataSetup', customDataSetupCommand(context))
   );
 }
 


### PR DESCRIPTION
## Description

`html.customData` feature is supported in `coc-html` v1.5.0 and later.

This command will make `customData`, which is built into `coc-html-css-support`, available at the workspace level.

Currently, supported `customData` are as follows.

- `Alpine.js`
- `petite-vue`

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/153858435-f02fe60e-ac2e-4738-b6b6-c481fdea46c9.mp4

## Misc

### What is customData?

You can read more about customData in the following repositories.

- <https://github.com/microsoft/vscode-custom-data>
- <https://github.com/Microsoft/vscode-html-languageservice/blob/main/docs/customData.md>

